### PR TITLE
[FIX] Fix the binnding problem on scheduler during parallelization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Changelog
 * |Enhancement| Improve the logging module | @zzzzwj
 * |API| Remove the input argument ``output_dim`` from all methods | @xuyxu
 * |Fix| Fix the bug in logging module when using multi-processing | @zzzzwj
-
+* |Fix| Fix the binding problem on scheduler and optimizer when using parallelization | @Alex-Medium and @xuyxi
 
 .. role:: raw-html(raw)
    :format: html

--- a/torchensemble/adversarial_training.py
+++ b/torchensemble/adversarial_training.py
@@ -432,7 +432,7 @@ class AdversarialTrainingRegressor(_BaseAdversarialTraining):
             scheduler_ = set_module.set_scheduler(optimizers[0],
                                                   self.scheduler_name,
                                                   **self.scheduler_args)
-        
+
         # Utils
         criterion = nn.MSELoss()
         best_mse = float("inf")

--- a/torchensemble/tests/test_set_optimizer.py
+++ b/torchensemble/tests/test_set_optimizer.py
@@ -42,3 +42,29 @@ def test_set_optimizer_Unknown():
     with pytest.raises(NotImplementedError) as excinfo:
         torchensemble.utils.set_module.set_optimizer(model, "Unknown")
     assert "Unknown name of the optimizer" in str(excinfo.value)
+
+
+def test_update_lr():
+    cur_lr = 1e-4
+    model = MLP()
+    optimizer = torchensemble.utils.set_module.set_optimizer(model,
+                                                             "Adam",
+                                                             lr=1e-3)
+
+    optimizer = torchensemble.utils.set_module.update_lr(optimizer, cur_lr)
+
+    for group in optimizer.param_groups:
+        assert group["lr"] == cur_lr
+
+
+def test_update_lr_invalid():
+    cur_lr = 0
+    model = MLP()
+    optimizer = torchensemble.utils.set_module.set_optimizer(model,
+                                                             "Adam",
+                                                             lr=1e-3)
+
+    err_msg = ("The learning rate should be strictly positive, but got"
+               " {} instead.").format(cur_lr)
+    with pytest.raises(ValueError, match=err_msg):
+        torchensemble.utils.set_module.update_lr(optimizer, cur_lr)

--- a/torchensemble/utils/set_module.py
+++ b/torchensemble/utils/set_module.py
@@ -36,6 +36,24 @@ def set_optimizer(model, optimizer_name, **kwargs):
     return optimizer
 
 
+def update_lr(optimizer, lr):
+    """
+    Manually update the learning rate of the optimizer. This function is used
+    when the parallelization corrupts the bindings between the optimizer and
+    the scheduler.
+    """
+
+    if not lr > 0:
+        msg = ("The learning rate should be strictly positive, but got"
+               " {} instead.")
+        raise ValueError(msg.format(lr))
+
+    for group in optimizer.param_groups:
+        group["lr"] = lr
+
+    return optimizer
+
+
 def set_scheduler(optimizer, scheduler_name, **kwargs):
     """
     Set the scheduler on learning rate for the optimizer.


### PR DESCRIPTION
Issue: #33 

This PR fixes the problem that the deepcopy operation during parallelization will corrupt the bindings between scheduler and optimizer.

As an alternative solution, we can extract the `lr` from the scheduler and ingest it to the optimizer in the body of parallelizaiton.