### PR TITLE
[ENH] Add heterogeneous support for Voting

### DIFF
--- a/torchensemble/mixing/voting.py
+++ b/torchensemble/mixing/voting.py
@@ -1,0 +1,59 @@
+"""
+  Extensions on the voting-based ensemble that supports heterogeneous models.
+"""
+
+
+import torch
+import logging
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .._base import torchensemble_model_doc
+from ..utils import io
+from ..utils import set_module
+from ..utils import operator as op
+
+
+class MixedVotingClassifier(nn.Module):
+
+    def __init__(self, cuda=True):
+        super(MixedVotingClassifier, self).__init__()
+
+        self.device = torch.device("cuda" if cuda else "cpu")
+        self.logger = logging.getLogger()
+        self.estimators_ = nn.ModuleList()
+        self.is_fitted = []  # flags on whether base estimators are fitted
+
+    def __repr__(self):
+        pass
+
+    def __str__(self):
+        return self.__repr__()
+
+    def forward(self, x):
+        outputs = [F.softmax(estimator(x), dim=1)
+                   for estimator in self.estimators_]
+        proba = op.average(outputs)
+
+        return proba
+
+    def pop(self, index):
+        """Pop the `index`-th base estimator in the ensemble."""
+        pass
+
+    def append(self, estimator, **estimator_args):
+        """Add a unfitted base estimator into the ensemble."""
+        pass
+
+    def fit(self,
+            train_loader,
+            epochs=100,
+            log_interval=100,
+            test_loader=None,
+            save_model=True,
+            save_dir=None):
+        """Fit the newly-added base estimator."""
+        pass
+
+    def predict(self, test_loader):
+        pass


### PR DESCRIPTION
Related issue: #5

This is an experimental feature that explores how to better support the training on heterogeneous base estimators in Ensemble-Pytorch. Unlike using base estimators of the same type, the training protocals on different base estimators can be quite different, therefore many methods used in existing ensembles cannot well support heterogeneous base estimators (e.g., `set_optimizer`, `set_scheduler`, `fit`).

An alternative solution is to enabling users to fit each base estimator in an incremental way. Specifically, the workflow below shows one way to support heterogeneous base estimators:
* Declare the ensemble (no base estimator included)
* For m = 1 to M:
  * Set the m-th base estimator
  * Set the optimizer and scheduler for the m-th base estimator
  *  Fit the m-th base estimator
  * Append the fitted base estimator onto the internal container on base estimators
 
Obviously, there is no way to support parallelization under this paradigm, but I think it is acceptable as state-of-the-art deep learning models typically have a bottleneck on computation, which makes parallelization less useful when only one GPU is available.

 In addition, users can also pop base estimators from the ensemble if they want.