### PR TITLE
[ENH] Support config when instantiating base estimators

### DIFF
--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -1,3 +1,4 @@
 flake8
 pytest-cov
 black==20.8b1
+pyyaml

--- a/torchensemble/_base.py
+++ b/torchensemble/_base.py
@@ -3,6 +3,7 @@ import torch
 import logging
 import torch.nn as nn
 
+from .utils import io
 from . import _constants as const
 
 
@@ -124,7 +125,17 @@ class BaseModule(abc.ABC, nn.Module):
         if self.estimator_args is None:
             estimator = self.base_estimator_()
         else:
-            estimator = self.base_estimator_(**self.estimator_args)
+            if isinstance(self.estimator_args, dict):
+                estimator = self.base_estimator_(**self.estimator_args)
+            elif isinstance(self.estimator_args, str):
+                config = io.get_config(self.estimator_args)
+                estimator = self.base_estimator_(config)
+            else:
+                msg = (
+                    "Cannot instantiate the base estimator because"
+                    " `estimator_args` is not one of {{None, dict, str}}."
+                )
+                raise ValueError(msg)
 
         return estimator.to(self.device)
 

--- a/torchensemble/utils/io.py
+++ b/torchensemble/utils/io.py
@@ -15,7 +15,7 @@ def get_config(cfg_dir):
         )
     _, extension = os.path.splitext(cfg_dir)
 
-    if extension == ".yaml":
+    if extension == ".yml":
         loader = yaml.SafeLoader
         loader.add_implicit_resolver(
             u"tag:yaml.org,2002:float",


### PR DESCRIPTION
Support `json` and `yaml` config file when making the base estimators internally.

### Steps
* [x] Add the implementation
* [ ] Add unit tests
* [ ] Update documentation